### PR TITLE
Limit Jobs#index to only the most recent jobs

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -3,7 +3,7 @@ class JobsController < ApplicationController
   before_filter :should_be_current_user, :only => [:edit, :update, :destroy]
   
   def index
-    @jobs = Job.all(:order => "created_at DESC")
+    @jobs = Job.where('created_at > ?', 1.year.ago).order("created_at DESC")
   end
 
   def show


### PR DESCRIPTION
Just to clean up the job listing a bit I've limited the display to only the items created within the last year.  I'm pretty sure most other vacancies are no longer interesting to anyone anyway.  ;-)  What do you think?
